### PR TITLE
Fix texture cleanup in Model by using disable

### DIFF
--- a/jgeroom/Model.java
+++ b/jgeroom/Model.java
@@ -72,8 +72,8 @@ public class Model {
 
     mesh.render(gl);
 
-    if (texture1 != null) texture1.unbind(gl);
-    if (texture2 != null) texture2.unbind(gl);
+    if (texture1 != null) texture1.disable(gl);
+    if (texture2 != null) texture2.disable(gl);
   }
 
   public void dispose(GL3 gl) {


### PR DESCRIPTION
## Summary
- Use `Texture.disable` to release textures after rendering

## Testing
- `javac Model.java` *(fails: package com.jogamp.common.nio does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6893d5c561e88325b3bf20e7ae7e948f