### PR TITLE
Fix texture asset paths in RoomScene

### DIFF
--- a/jgeroom/RoomScene.java
+++ b/jgeroom/RoomScene.java
@@ -43,15 +43,15 @@ public class RoomScene implements GLEventListener {
     light.setLightColour(new Vec3(1, 1, 1));
 
     // Load Textures
-    Texture t_floor = TextureLibrary.loadTexture(gl, "textures/chequerboard.jpg");
-    Texture t_back = TextureLibrary.loadTexture(gl, "textures/noticeboard.jpg");
-    Texture t_right = TextureLibrary.loadTexture(gl, "textures/container2.jpg");
-    Texture t_window = TextureLibrary.loadTexture(gl, "textures/cloud.jpg");
+    Texture t_floor = TextureLibrary.loadTexture(gl, "assets/textures/chequerboard.jpg");
+    Texture t_back = TextureLibrary.loadTexture(gl, "assets/textures/noticeboard.jpg");
+    Texture t_right = TextureLibrary.loadTexture(gl, "assets/textures/container2.jpg");
+    Texture t_window = TextureLibrary.loadTexture(gl, "assets/textures/cloud.jpg");
 
-    Texture poster1 = TextureLibrary.loadTexture(gl, "textures/poster2.jpg");
-    Texture poster2 = TextureLibrary.loadTexture(gl, "textures/poster3.jpg");
-    Texture poster2Spec = TextureLibrary.loadTexture(gl, "textures/poster3_specular.jpg");
-    Texture poster3 = TextureLibrary.loadTexture(gl, "textures/wattBook.jpg");
+    Texture poster1 = TextureLibrary.loadTexture(gl, "assets/textures/poster2.jpg");
+    Texture poster2 = TextureLibrary.loadTexture(gl, "assets/textures/poster3.jpg");
+    Texture poster2Spec = TextureLibrary.loadTexture(gl, "assets/textures/poster3_specular.jpg");
+    Texture poster3 = TextureLibrary.loadTexture(gl, "assets/textures/wattBook.jpg");
 
     // Build the room scene
     myRoom = new room(gl, camera, light, t_floor, t_back, t_right, t_window,


### PR DESCRIPTION
## Summary
- correct texture file paths in RoomScene to load from assets directory

## Testing
- `javac jgeroom/RoomScene.java` *(fails: package com.jogamp.opengl.util.texture does not exist)*
- `sudo apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b24453ec83259bc043720e8e6ba8