### PR TITLE
Add textured room with window and repeating wall

### DIFF
--- a/jgeroom/RoomScene.java
+++ b/jgeroom/RoomScene.java
@@ -45,7 +45,11 @@ public class RoomScene implements GLEventListener {
     // Load Textures
     Texture t_floor = TextureLibrary.loadTexture(gl, "assets/textures/chequerboard.jpg");
     Texture t_back = TextureLibrary.loadTexture(gl, "assets/textures/noticeboard.jpg");
-    Texture t_right = TextureLibrary.loadTexture(gl, "assets/textures/container2.jpg");
+    Texture t_right = TextureLibrary.loadTexture(gl, "assets/textures/cat.jpg");
+    t_right.bind(gl);
+    t_right.setTexParameteri(gl, GL3.GL_TEXTURE_WRAP_S, GL3.GL_REPEAT);
+    t_right.setTexParameteri(gl, GL3.GL_TEXTURE_WRAP_T, GL3.GL_REPEAT);
+    Texture t_left = TextureLibrary.loadTexture(gl, "assets/textures/container2.jpg");
     Texture t_window = TextureLibrary.loadTexture(gl, "assets/textures/cloud.jpg");
 
     Texture poster1 = TextureLibrary.loadTexture(gl, "assets/textures/poster2.jpg");
@@ -54,7 +58,7 @@ public class RoomScene implements GLEventListener {
     Texture poster3 = TextureLibrary.loadTexture(gl, "assets/textures/wattBook.jpg");
 
     // Build the room scene
-    myRoom = new room(gl, camera, light, t_floor, t_back, t_right, t_window,
+    myRoom = new room(gl, camera, light, t_floor, t_back, t_right, t_left, t_window,
                       poster1, poster2, poster2Spec, poster3);
   }
 

--- a/jgeroom/room.java
+++ b/jgeroom/room.java
@@ -1,22 +1,24 @@
 import gmaths.*;
 import com.jogamp.opengl.*;
 import com.jogamp.opengl.util.texture.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class room {
 
-  private Model[] wall;
+  private List<Model> walls;
   private Model[] posters;
   private Camera camera;
   private Light light;
 
   // Textures
-  private Texture t_floor, t_back, t_right, t_window;
+  private Texture t_floor, t_back, t_right, t_left, t_window;
   private Texture poster1Tex, poster2Tex, poster2Spec, poster3Tex;
 
   private float size = 16f;
 
   public room(GL3 gl, Camera c, Light light,
-              Texture t_floor, Texture t_back, Texture t_right, Texture t_window,
+              Texture t_floor, Texture t_back, Texture t_right, Texture t_left, Texture t_window,
               Texture poster1Tex, Texture poster2Tex, Texture poster2Spec, Texture poster3Tex) {
 
     this.camera = c;
@@ -24,17 +26,18 @@ public class room {
     this.t_floor = t_floor;
     this.t_back = t_back;
     this.t_right = t_right;
+    this.t_left = t_left;
     this.t_window = t_window;
     this.poster1Tex = poster1Tex;
     this.poster2Tex = poster2Tex;
     this.poster2Spec = poster2Spec;
     this.poster3Tex = poster3Tex;
 
-    wall = new Model[4];
-    wall[0] = makeFloor(gl);
-    wall[1] = makeBackWall(gl);
-    wall[2] = makeRightWall(gl);
-    wall[3] = makeLeftWallWithWindow(gl);
+    walls = new ArrayList<>();
+    walls.add(makeFloor(gl));
+    walls.add(makeBackWall(gl));
+    walls.add(makeRightWall(gl));
+    addLeftWallWithWindow(gl);
 
     posters = new Model[3];
     posters[0] = makePoster(gl, -4f, 5f, poster1Tex, null);              // Poster 1 - no specular
@@ -62,16 +65,55 @@ public class room {
     m = Mat4.multiply(Mat4Transform.rotateAroundY(90), m);
     m = Mat4.multiply(Mat4Transform.rotateAroundZ(-90), m);
     m = Mat4.multiply(Mat4Transform.translate(-size*0.5f,size*0.5f,0), m);
-    return createQuad(gl, "rightWall", t_right, null, m);
+    return createQuadRepeat(gl, "rightWall", t_right, null, m, 4f, 4f);
   }
+  
+  private void addLeftWallWithWindow(GL3 gl) {
+    float border = 4f;
+    float windowWidth = size - 2 * border;
+    float windowHeight = size - 2 * border;
 
-  private Model makeLeftWallWithWindow(GL3 gl) {
-    Mat4 m = new Mat4(1);
-    m = Mat4.multiply(Mat4Transform.scale(size,1f,size), m);
+    Mat4 m;
+
+    // Left vertical strip
+    m = new Mat4(1);
+    m = Mat4.multiply(Mat4Transform.scale(border, 1f, size), m);
     m = Mat4.multiply(Mat4Transform.rotateAroundY(-90), m);
     m = Mat4.multiply(Mat4Transform.rotateAroundZ(-90), m);
-    m = Mat4.multiply(Mat4Transform.translate(size*0.5f,size*0.5f,0), m);
-    return createQuad(gl, "leftWall", t_window, null, m);
+    m = Mat4.multiply(Mat4Transform.translate(size * 0.5f, size * 0.5f, -size * 0.5f + border * 0.5f), m);
+    walls.add(createQuad(gl, "leftWallSideL", t_left, null, m));
+
+    // Right vertical strip
+    m = new Mat4(1);
+    m = Mat4.multiply(Mat4Transform.scale(border, 1f, size), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundY(-90), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundZ(-90), m);
+    m = Mat4.multiply(Mat4Transform.translate(size * 0.5f, size * 0.5f, size * 0.5f - border * 0.5f), m);
+    walls.add(createQuad(gl, "leftWallSideR", t_left, null, m));
+
+    // Top strip
+    m = new Mat4(1);
+    m = Mat4.multiply(Mat4Transform.scale(windowWidth, 1f, border), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundY(-90), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundZ(-90), m);
+    m = Mat4.multiply(Mat4Transform.translate(size * 0.5f, size - border * 0.5f, 0), m);
+    walls.add(createQuad(gl, "leftWallTop", t_left, null, m));
+
+    // Bottom strip
+    m = new Mat4(1);
+    m = Mat4.multiply(Mat4Transform.scale(windowWidth, 1f, border), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundY(-90), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundZ(-90), m);
+    m = Mat4.multiply(Mat4Transform.translate(size * 0.5f, border * 0.5f, 0), m);
+    walls.add(createQuad(gl, "leftWallBottom", t_left, null, m));
+
+    // Outside view
+    m = new Mat4(1);
+    m = Mat4.multiply(Mat4Transform.scale(windowWidth, 1f, windowHeight), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundY(-90), m);
+    m = Mat4.multiply(Mat4Transform.rotateAroundZ(-90), m);
+    m = Mat4.multiply(Mat4Transform.translate(size * 0.5f + 0.1f, size * 0.5f, 0), m);
+    walls.add(createQuad(gl, "windowView", t_window, null, m));
   }
 
   // POSTERS ------------------
@@ -108,8 +150,27 @@ public class room {
     }
   }
 
+  private Model createQuadRepeat(GL3 gl, String name, Texture t1, Texture t2, Mat4 modelMatrix, float repeatU, float repeatV) {
+    Material mat = new Material(new Vec3(1f,1f,1f), new Vec3(1f,1f,1f), new Vec3(0.3f,0.3f,0.3f), 32f);
+    float[] verts = {
+      -0.5f, 0.0f, -0.5f,  0.0f,1.0f,0.0f,  0.0f, repeatV,
+      -0.5f, 0.0f,  0.5f,  0.0f,1.0f,0.0f,  0.0f, 0.0f,
+       0.5f, 0.0f,  0.5f,  0.0f,1.0f,0.0f,  repeatU, 0.0f,
+       0.5f, 0.0f, -0.5f,  0.0f,1.0f,0.0f,  repeatU, repeatV
+    };
+    Mesh mesh = new Mesh(gl, verts, TwoTriangles.indices.clone());
+    Shader shader;
+    if (t2 != null) {
+      shader = new Shader(gl, "assets/shaders/vs_standard.txt", "assets/shaders/fs_standard_2t.txt");
+      return new Model(name, mesh, modelMatrix, shader, mat, light, camera, t1, t2);
+    } else {
+      shader = new Shader(gl, "assets/shaders/vs_standard.txt", "assets/shaders/fs_standard_1t.txt");
+      return new Model(name, mesh, modelMatrix, shader, mat, light, camera, t1);
+    }
+  }
+
   public void render(GL3 gl) {
-    for (Model m : wall) {
+    for (Model m : walls) {
       m.render(gl);
     }
     for (Model p : posters) {
@@ -118,7 +179,7 @@ public class room {
   }
 
   public void dispose(GL3 gl) {
-    for (Model m : wall) m.dispose(gl);
+    for (Model m : walls) m.dispose(gl);
     for (Model p : posters) p.dispose(gl);
   }
 }


### PR DESCRIPTION
## Summary
- Texture the floor, back wall, and repetitive cat-covered right wall
- Carve a window into the left wall and place an outdoor cloud view behind it
- Support posters including a specular-mapped one on a notice board

## Testing
- `javac jgeroom/*.java` *(fails: package com.jogamp.opengl.awt does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6894b74078648325b3f70c4625608a85