### PR TITLE
Fix keyboard input switch syntax and poster material initialization

### DIFF
--- a/jgeroom/MyKeyboardInput.java
+++ b/jgeroom/MyKeyboardInput.java
@@ -11,13 +11,27 @@ public class MyKeyboardInput extends KeyAdapter {
   @Override
   public void keyPressed(KeyEvent e) {
     switch (e.getKeyCode()) {
-      case KeyEvent.VK_W -> camera.keyboardInput(Camera.Movement.FORWARD);
-      case KeyEvent.VK_S -> camera.keyboardInput(Camera.Movement.BACK);
-      case KeyEvent.VK_A -> camera.keyboardInput(Camera.Movement.LEFT);
-      case KeyEvent.VK_D -> camera.keyboardInput(Camera.Movement.RIGHT);
-      case KeyEvent.VK_Q -> camera.keyboardInput(Camera.Movement.DOWN);
-      case KeyEvent.VK_E -> camera.keyboardInput(Camera.Movement.UP);
-      default -> camera.keyboardInput(Camera.Movement.NO_MOVEMENT);
+      case KeyEvent.VK_W:
+        camera.keyboardInput(Camera.Movement.FORWARD);
+        break;
+      case KeyEvent.VK_S:
+        camera.keyboardInput(Camera.Movement.BACK);
+        break;
+      case KeyEvent.VK_A:
+        camera.keyboardInput(Camera.Movement.LEFT);
+        break;
+      case KeyEvent.VK_D:
+        camera.keyboardInput(Camera.Movement.RIGHT);
+        break;
+      case KeyEvent.VK_Q:
+        camera.keyboardInput(Camera.Movement.DOWN);
+        break;
+      case KeyEvent.VK_E:
+        camera.keyboardInput(Camera.Movement.UP);
+        break;
+      default:
+        camera.keyboardInput(Camera.Movement.NO_MOVEMENT);
+        break;
     }
   }
 }

--- a/jgeroom/room.java
+++ b/jgeroom/room.java
@@ -118,7 +118,7 @@ public class room {
 
 // POSTERS ------------------
   private Model makePoster(GL3 gl, float x, float y, Texture tex, Texture specTex) {
-    Material material = new Material(new Vec3(1f), new Vec3(1f), new Vec3(0.5f), 32.0f);
+    Material material = new Material(new Vec3(1f,1f,1f), new Vec3(1f,1f,1f), new Vec3(0.5f,0.5f,0.5f), 32.0f);
 
     // Transformation: scale first, then translate slightly backward
     Mat4 m = new Mat4(1);


### PR DESCRIPTION
## Summary
- Replace Java 14+ switch arrows with classic switch statements in `MyKeyboardInput` for compatibility
- Initialize poster material using explicit `Vec3` components to match constructor requirements

## Testing
- `javac Main.java` *(fails: package com.jogamp.opengl.awt does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6894cb5108988325a9dbeecb4f10ea2b