### PR TITLE
Prevent null pointer in keyboard input handler

### DIFF
--- a/jgeroom/MyKeyboardInput.java
+++ b/jgeroom/MyKeyboardInput.java
@@ -10,6 +10,9 @@ public class MyKeyboardInput extends KeyAdapter {
 
   @Override
   public void keyPressed(KeyEvent e) {
+    if (camera == null) {
+      return;
+    }
     switch (e.getKeyCode()) {
       case KeyEvent.VK_W:
         camera.keyboardInput(Camera.Movement.FORWARD);


### PR DESCRIPTION
## Summary
- avoid NullPointerException in `MyKeyboardInput` when camera is not yet initialised

## Testing
- `javac -cp jgeroom jgeroom/MyKeyboardInput.java`


------
https://chatgpt.com/codex/tasks/task_e_6894cc5ca8148325962d9b072d530d6d