### PR TITLE
Fix poster specular texture affecting entire scene

### DIFF
--- a/jgeroom/Model.java
+++ b/jgeroom/Model.java
@@ -72,8 +72,17 @@ public class Model {
 
     mesh.render(gl);
 
-    if (texture1 != null) texture1.disable(gl);
-    if (texture2 != null) texture2.disable(gl);
+    // Unbind textures after rendering to avoid leaking state across models
+    if (texture2 != null) {
+      gl.glActiveTexture(GL.GL_TEXTURE1);
+      texture2.disable(gl);
+    }
+    if (texture1 != null) {
+      gl.glActiveTexture(GL.GL_TEXTURE0);
+      texture1.disable(gl);
+    }
+    // Reset active texture to default
+    gl.glActiveTexture(GL.GL_TEXTURE0);
   }
 
   public void dispose(GL3 gl) {


### PR DESCRIPTION
## Summary
- Properly unbind textures after model rendering to prevent specular map from leaking into subsequent draws

## Testing
- `javac Model.java` *(fails: cannot find symbol com.jogamp.opengl)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce071404832592171b039b0a759d