### PR TITLE
Use grayscale specular map intensity

### DIFF
--- a/jgeroom/assets/shaders/fs_standard_2t.txt
+++ b/jgeroom/assets/shaders/fs_standard_2t.txt
@@ -40,9 +40,10 @@ void main() {
   
   // specular 
   vec3 viewDir = normalize(viewPos - aPos);
-  vec3 reflectDir = reflect(-lightDir, norm);  
+  vec3 reflectDir = reflect(-lightDir, norm);
   float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-  vec3 specular = light.specular * spec * vec3(texture(second_texture, aTexCoord));
+  float specMap = texture(second_texture, aTexCoord).r;
+  vec3 specular = light.specular * spec * specMap;
 
   vec3 result = ambient + diffuse + specular;
   fragColor = vec4(result, 1.0);

--- a/jgeroom/assets/shaders/fs_standard_m_2t.txt
+++ b/jgeroom/assets/shaders/fs_standard_m_2t.txt
@@ -40,9 +40,10 @@ vec3 CalcPointLight(Light light, vec3 norm, vec3 aPos, vec3 viewDir) {
   vec3 diffuse = light.diffuse * diff  * texture(first_texture, aTexCoord).rgb;
   
   // specular 
-  vec3 reflectDir = reflect(-lightDir, norm);  
+  vec3 reflectDir = reflect(-lightDir, norm);
   float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-  vec3 specular = light.specular * spec * vec3(texture(second_texture, aTexCoord));
+  float specMap = texture(second_texture, aTexCoord).r;
+  vec3 specular = light.specular * spec * specMap;
  
   vec3 result = ambient + diffuse + specular;
   return result;


### PR DESCRIPTION
## Summary
- Remove color influence from specular maps by sampling only the red channel in fragment shaders.
- Apply the same grayscale specular mapping logic to multi-light shader variant.

## Testing
- `javac jgeroom/Main.java` *(fails: package com.jogamp.opengl.awt does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6894d12be1d083258b1f8141e9274318